### PR TITLE
PCHR-2427: Add xunit to JS testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,6 +170,27 @@ pipeline {
 					}
 				}
 			}
+			post {
+                always {
+                	// XUnit
+					step([
+	                    $class: 'XUnitBuilder',
+                    	thresholds: [
+	                    	[$class: 'FailedThreshold',
+	                          failureNewThreshold: '5',
+	                          failureThreshold: '5',
+	                          unstableNewThreshold: '1',
+	                          unstableThreshold: '1'],
+	                        [$class: 'SkippedThreshold',
+	                          failureNewThreshold: '0',
+	                          failureThreshold: '0',
+	                          unstableNewThreshold: '0',
+	                          unstableThreshold: '0']
+                    	],
+	                    tools: [[$class: 'JUnitType', pattern: 'reports/js-karma/*.xml']]
+	                ])
+            	}
+            }
 	    }
   	}
 


### PR DESCRIPTION
## Overview
Add xunit post step to JS testing part in order to 
- Enable testing without stopping at fail
- Enable threshold settings
- Jenkins to generate test report

## Before

## After

## Technical Details

## Comments

---

- [ ] Tests Pass
